### PR TITLE
feat(rebuild/child): avoid rebuild provided child

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class MyHomePage extends StatelessWidget {
           title: Connect<State, String>(
             convert: (state) => state.title,
             where: (prev, next) => next != prev,
-            builder: (title) {
+            builder: (title, child) {
               print('Building title: $title');
               return Text(title);
             },
@@ -52,7 +52,7 @@ class MyHomePage extends StatelessWidget {
               Connect<State, String>(
                 convert: (state) => state.count.toString(),
                 where: (prev, next) => next != prev,
-                builder: (count) {
+                builder: (count, child) {
                   print('Building counter: $count');
                   return Text(count,
                       style: Theme.of(context).textTheme.display1);

--- a/lib/flutter_redurx.dart
+++ b/lib/flutter_redurx.dart
@@ -43,23 +43,36 @@ class Connect<S, P> extends StatefulWidget {
     @required this.where,
     @required this.builder,
     this.nullable = false,
+    this.child,
   }) : super(key: key);
 
   final P Function(S state) convert;
   final bool Function(P oldState, P newState) where;
-  final Widget Function(P state) builder;
+  final Widget Function(P state, Widget child) builder;
   final bool nullable;
 
+  /// If the pre-built subtree is passed as the [child] parameter, it
+  /// will pass it back to the [builder] function so that it
+  /// can be incorporated into the build.
+  ///
+  /// Using this pre-built child is entirely optional, but can improve
+  /// performance significantly in some cases and is therefore a good practice.
+  final Widget child;
+
   @override
-  _ConnectState createState() => _ConnectState<S, P>(where, builder, nullable);
+  _ConnectState createState() =>
+      _ConnectState<S, P>(where, builder, nullable, child);
 }
 
 class _ConnectState<S, P> extends State<Connect<S, P>> {
-  _ConnectState(this.where, this.builder, this.nullable);
+  _ConnectState(this.where, this.builder, this.nullable, this.child);
 
   final bool Function(P oldState, P newState) where;
-  final Widget Function(P state) builder;
+  final Widget Function(P state, Widget child) builder;
   final bool nullable;
+
+  /// The part of the widget tree not rebuilt on change.
+  final Widget child;
 
   P _prev;
   Store<S> _store;
@@ -85,7 +98,7 @@ class _ConnectState<S, P> extends State<Connect<S, P>> {
         }
 
         _prev = snapshot.data;
-        return builder(_prev);
+        return builder(_prev, child);
       },
     );
   }


### PR DESCRIPTION
To improve performance by having less rebuilds, the part of the tree rebuilt
by builder should be minimized by putting as much of the tree in [child] as
possible