### PR TITLE
add named Constructor for Connect

### DIFF
--- a/lib/flutter_redurx.dart
+++ b/lib/flutter_redurx.dart
@@ -44,6 +44,14 @@ class Connect<S, P> extends StatefulWidget {
     @required this.builder,
     this.nullable = false,
   }) : super(key: key);
+  
+  Connect.distinct({
+    Key key,
+    @required this.convert,
+    @required this.builder,
+    this.where = (oldState, newState) => oldState != newState,
+    this.nullable = false,
+  }) : super(key: key);
 
   final P Function(S state) convert;
   final bool Function(P oldState, P newState) where;

--- a/lib/flutter_redurx.dart
+++ b/lib/flutter_redurx.dart
@@ -40,14 +40,6 @@ class Connect<S, P> extends StatefulWidget {
   Connect({
     Key key,
     @required this.convert,
-    @required this.where,
-    @required this.builder,
-    this.nullable = false,
-  }) : super(key: key);
-  
-  Connect.distinct({
-    Key key,
-    @required this.convert,
     @required this.builder,
     this.where = (oldState, newState) => oldState != newState,
     this.nullable = false,


### PR DESCRIPTION
in nearly every case the Function where is the same,
user of this plugin should not have to write this line
where: (old, next) => old != next,
over and over again.